### PR TITLE
Updated components to latest AutoMapper and NodaTime, removed unsupported functionality, fixed unit test

### DIFF
--- a/AutoMapper.NodaTime-NET46.UnitTests/AutoMapper.NodaTime-NET46.UnitTests.csproj
+++ b/AutoMapper.NodaTime-NET46.UnitTests/AutoMapper.NodaTime-NET46.UnitTests.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C55CADC8-7CA4-4CB6-AAA8-56DE7A4EF37B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AutoMapper.NodaTime.UnitTests</RootNamespace>
+    <AssemblyName>AutoMapper.NodaTime.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="AutoMapper, Version=6.0.2.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.6.0.2\lib\net45\AutoMapper.dll</HintPath>
+    </Reference>
+    <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DurationTests.cs" />
+    <Compile Include="InstantTests.cs" />
+    <Compile Include="OffsetDateTimeTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AutoMapper.NodaTime-Net46\AutoMapper.NodaTime %28Net46%29.csproj">
+      <Project>{fb772c38-2e94-4633-acc7-6a1b34fe39de}</Project>
+      <Name>AutoMapper.NodaTime %28Net46%29</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/AutoMapper.NodaTime-NET46.UnitTests/DurationTests.cs
+++ b/AutoMapper.NodaTime-NET46.UnitTests/DurationTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using NodaTime;
+using Xunit;
+
+namespace AutoMapper.NodaTime.UnitTests
+{
+    public class DurationTests
+    {
+        private readonly IMapper _mapper;
+
+        public DurationTests()
+        { 
+            var config = new MapperConfiguration(x =>
+                {
+                    x.AddProfile<NodaTimeProfile>();
+
+                    x.CreateMap<Foo1, Foo3>().ReverseMap();
+                    x.CreateMap<Foo2, Foo4>().ReverseMap();
+                    x.CreateMap<Foo1, Foo5>().ReverseMap();
+                    x.CreateMap<Foo2, Foo6>().ReverseMap();
+                    x.CreateMap<Foo1, Foo7>().ReverseMap();
+                    x.CreateMap<Foo2, Foo8>().ReverseMap();
+                }
+            );
+
+            config.AssertConfigurationIsValid();
+
+            _mapper = config.CreateMapper();
+        }
+
+        [Fact]
+        public void CanConvertDurationToMinutes()
+        {
+            var foo = new Foo1 { Bar = Duration.FromMinutes(300) };
+
+            var o = _mapper.Map<Foo7>(foo);
+
+            Assert.Equal(18000, o.Bar);
+        }
+
+        [Fact]
+        public void CanConvertMinutesToDuration()
+        {
+            var foo = new Foo7 { Bar = 300 };
+
+            var o = _mapper.Map<Foo1>(foo);
+
+            Assert.Equal(Duration.FromMinutes(5), o.Bar);
+        }
+
+        public class Foo1
+        {
+            public Duration Bar { get; set; }
+        }
+
+        public class Foo2
+        {
+            public Duration? Bar { get; set; }
+        }
+
+        public class Foo3
+        {
+            public TimeSpan Bar { get; set; }
+        }
+
+        public class Foo4
+        {
+            public TimeSpan? Bar { get; set; }
+        }
+
+        public class Foo5
+        {
+            public long Bar { get; set; }
+        }
+
+        public class Foo6
+        {
+            public long? Bar { get; set; }
+        }
+
+        public class Foo7
+        {
+            public int Bar { get; set; }
+        }
+
+        public class Foo8
+        {
+            public int? Bar { get; set; }
+        }
+    }
+}

--- a/AutoMapper.NodaTime-NET46.UnitTests/InstantTests.cs
+++ b/AutoMapper.NodaTime-NET46.UnitTests/InstantTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using NodaTime;
+using Xunit;
+
+namespace AutoMapper.NodaTime.UnitTests
+{
+    public class InstantTests
+    {
+        [Fact]
+        public void ValidateMapping()
+        {
+            var config = new MapperConfiguration(x =>
+                {
+                    x.AddProfile<NodaTimeProfile>();
+
+                    x.CreateMap<Foo1, Foo3>().ReverseMap();
+                    x.CreateMap<Foo2, Foo4>().ReverseMap();
+                    x.CreateMap<Foo1, Foo5>().ReverseMap();
+                    x.CreateMap<Foo2, Foo6>().ReverseMap();
+                }
+            );
+
+            config.AssertConfigurationIsValid();
+        }
+
+        public class Foo1
+        {
+            public Instant Bar { get; set; }
+        }
+
+        public class Foo2
+        {
+            public Instant? Bar { get; set; }
+        }
+
+        public class Foo3
+        {
+            public DateTime Bar { get; set; }
+        }
+
+        public class Foo4
+        {
+            public DateTime? Bar { get; set; }
+        }
+
+        public class Foo5
+        {
+            public DateTimeOffset Bar { get; set; }
+        }
+
+        public class Foo6
+        {
+            public DateTimeOffset? Bar { get; set; }
+        }
+    }
+}

--- a/AutoMapper.NodaTime-NET46.UnitTests/OffsetDateTimeTests.cs
+++ b/AutoMapper.NodaTime-NET46.UnitTests/OffsetDateTimeTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using NodaTime;
+using Xunit;
+
+namespace AutoMapper.NodaTime.UnitTests
+{
+    public class OffsetDateTimeTests
+    {
+        [Fact]
+        public void ValidateMapping()
+        {
+            var config = new MapperConfiguration(x =>
+                {
+                    x.AddProfile<NodaTimeProfile>();
+
+                    x.CreateMap<Foo1, Foo3>().ReverseMap();
+                    x.CreateMap<Foo2, Foo4>().ReverseMap();
+                    x.CreateMap<Foo3, Foo1>().ReverseMap();
+                    x.CreateMap<Foo4, Foo2>().ReverseMap();
+                }
+            );
+
+            config.AssertConfigurationIsValid();
+        }
+
+        public class Foo1
+        {
+            public OffsetDateTime Bar { get; set; }
+        }
+
+        public class Foo2
+        {
+            public OffsetDateTime? Bar { get; set; }
+        }
+
+        public class Foo3
+        {
+            public DateTimeOffset Bar { get; set; }
+        }
+
+        public class Foo4
+        {
+            public DateTimeOffset? Bar { get; set; }
+        }
+    }
+}

--- a/AutoMapper.NodaTime-NET46.UnitTests/Properties/AssemblyInfo.cs
+++ b/AutoMapper.NodaTime-NET46.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("AutoMapper.NodaTime-NET46.UnitTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AutoMapper.NodaTime-NET46.UnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("c55cadc8-7ca4-4cb6-aaa8-56de7a4ef37b")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/AutoMapper.NodaTime-NET46.UnitTests/packages.config
+++ b/AutoMapper.NodaTime-NET46.UnitTests/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AutoMapper" version="6.0.2" targetFramework="net461" />
+  <package id="NodaTime" version="1.3.4" targetFramework="net461" />
+  <package id="xunit" version="2.1.0" targetFramework="net461" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net461" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net461" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net461" />
+</packages>

--- a/AutoMapper.NodaTime-Net46/AutoMapper.NodaTime (Net46).csproj
+++ b/AutoMapper.NodaTime-Net46/AutoMapper.NodaTime (Net46).csproj
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FB772C38-2E94-4633-ACC7-6A1B34FE39DE}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AutoMapper.NodaTime</RootNamespace>
+    <AssemblyName>AutoMapper.NodaTime</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="AutoMapper, Version=6.0.2.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.6.0.2\lib\net45\AutoMapper.dll</HintPath>
+    </Reference>
+    <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="NodaTimeProfile.cs" />
+    <Compile Include="DurationConverter.cs" />
+    <Compile Include="InstantConverter.cs" />
+    <Compile Include="LocalDateConverter.cs" />
+    <Compile Include="LocalDateTimeConverter.cs" />
+    <Compile Include="LocalTimeConverter.cs" />
+    <Compile Include="OffsetConverter.cs" />
+    <Compile Include="OffsetDateTimeConverter.cs" />
+    <Compile Include="PeriodConverter.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/AutoMapper.NodaTime-Net46/DurationConverter.cs
+++ b/AutoMapper.NodaTime-Net46/DurationConverter.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using NodaTime;
+
+namespace AutoMapper.NodaTime
+{
+    public class DurationConverter :
+        ITypeConverter<Duration, TimeSpan>,
+        ITypeConverter<Duration?, TimeSpan?>,
+        ITypeConverter<TimeSpan, Duration>,
+        ITypeConverter<TimeSpan?, Duration?>,
+        ITypeConverter<Duration, long>,
+        ITypeConverter<Duration?, long?>,
+        ITypeConverter<long, Duration>,
+        ITypeConverter<long?, Duration?>,
+        ITypeConverter<Duration, int>,
+        ITypeConverter<Duration?, int?>,
+        ITypeConverter<int, Duration>,
+        ITypeConverter<int?, Duration?>,
+        ITypeConverter<Duration, double>,
+        ITypeConverter<Duration?, double?>,
+        ITypeConverter<double, Duration>,
+        ITypeConverter<double?, Duration?>,
+        ITypeConverter<Duration, decimal>,
+        ITypeConverter<Duration?, decimal?>,
+        ITypeConverter<decimal, Duration>,
+        ITypeConverter<decimal?, Duration?>
+    {
+        public TimeSpan Convert(Duration source, TimeSpan destination, ResolutionContext context)
+        {
+            return source.ToTimeSpan();
+        }
+
+        public TimeSpan? Convert(Duration? source, TimeSpan? destination, ResolutionContext context)
+        {
+            return source?.ToTimeSpan();
+        }
+
+        public Duration Convert(TimeSpan source, Duration destination, ResolutionContext context)
+        {
+            return Duration.FromTimeSpan(source);
+        }
+
+        public Duration? Convert(TimeSpan? source, Duration? destination, ResolutionContext context)
+        {
+            return source != null ? (Duration?)Duration.FromTimeSpan(source.Value) : null;
+        }
+
+        public long Convert(Duration source, long destination, ResolutionContext context)
+        {
+            return source.Ticks / NodaConstants.TicksPerSecond;
+        }
+
+        public long? Convert(Duration? source, long? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return source.Value.Ticks / NodaConstants.TicksPerSecond;
+        }
+
+        public Duration Convert(long source, Duration destination, ResolutionContext context)
+        {
+            return Duration.FromTicks(source * NodaConstants.TicksPerSecond);
+        }
+
+        public Duration? Convert(long? source, Duration? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return Duration.FromTicks(source.Value * NodaConstants.TicksPerSecond);
+        }
+
+        public int Convert(Duration source, int destination, ResolutionContext context)
+        {
+            return (int)(source.Ticks / NodaConstants.TicksPerSecond);
+        }
+
+        public int? Convert(Duration? source, int? destination, ResolutionContext context)
+        {
+            if (source == null)
+                return null;
+
+            return (int)(source.Value.Ticks / NodaConstants.TicksPerSecond);
+        }
+
+        public Duration Convert(int source, Duration destination, ResolutionContext context)
+        {
+            return Duration.FromTicks(source * NodaConstants.TicksPerSecond);
+        }
+
+        public Duration? Convert(int? source, Duration? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return Duration.FromTicks(source.Value * NodaConstants.TicksPerSecond);
+        }
+
+        public double Convert(Duration source, double destination, ResolutionContext context)
+        {
+            return (double)source.Ticks / NodaConstants.TicksPerSecond;
+        }
+
+        public double? Convert(Duration? source, double? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return (double)source.Value.Ticks / NodaConstants.TicksPerSecond;
+        }
+
+        public Duration Convert(double source, Duration destination, ResolutionContext context)
+        {
+            return Duration.FromTicks((long)(source * NodaConstants.TicksPerSecond));
+        }
+
+        public Duration? Convert(double? source, Duration? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return Duration.FromTicks((long)(source.Value * NodaConstants.TicksPerSecond));
+        }
+
+        public decimal Convert(Duration source, decimal destination, ResolutionContext context)
+        {
+            return (decimal)source.Ticks / NodaConstants.TicksPerSecond;
+        }
+
+        public decimal? Convert(Duration? source, decimal? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return (decimal)source.Value.Ticks / NodaConstants.TicksPerSecond;
+        }
+
+        public Duration Convert(decimal source, Duration destination, ResolutionContext context)
+        {
+            return Duration.FromTicks((long)(source * NodaConstants.TicksPerSecond));
+        }
+
+        public Duration? Convert(decimal? source, Duration? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return Duration.FromTicks((long)(source.Value * NodaConstants.TicksPerSecond));
+        }
+    }
+}

--- a/AutoMapper.NodaTime-Net46/InstantConverter.cs
+++ b/AutoMapper.NodaTime-Net46/InstantConverter.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using NodaTime;
+
+namespace AutoMapper.NodaTime
+{
+    public class InstantConverter :
+        ITypeConverter<Instant, DateTime>,
+        ITypeConverter<Instant?, DateTime?>,
+        ITypeConverter<Instant, DateTimeOffset>,
+        ITypeConverter<Instant?, DateTimeOffset?>,
+        ITypeConverter<DateTime, Instant>,
+        ITypeConverter<DateTime?, Instant?>,
+        ITypeConverter<DateTimeOffset, Instant>,
+        ITypeConverter<DateTimeOffset?, Instant?>
+    {
+        public DateTime Convert(Instant source, DateTime destination, ResolutionContext context)
+        {
+            return source.ToDateTimeUtc();
+        }
+
+        public DateTime? Convert(Instant? source, DateTime? destination, ResolutionContext context)
+        {
+            return source?.ToDateTimeUtc();
+        }
+
+        public DateTimeOffset Convert(Instant source, DateTimeOffset destination, ResolutionContext context)
+        {
+            return source.ToDateTimeOffset();
+        }
+
+        public DateTimeOffset? Convert(Instant? source, DateTimeOffset? destination, ResolutionContext context)
+        {
+            return source?.ToDateTimeOffset();
+        }
+
+        public Instant Convert(DateTime source, Instant destination, ResolutionContext context)
+        {
+            var utcDateTime = source.Kind == DateTimeKind.Unspecified
+                ? DateTime.SpecifyKind(source, DateTimeKind.Utc)
+                : source.ToUniversalTime();
+
+            return Instant.FromDateTimeUtc(utcDateTime);
+        }
+
+        public Instant? Convert(DateTime? source, Instant? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            var dateTime = source.Value;
+            var utcDateTime = dateTime.Kind == DateTimeKind.Unspecified
+                ? DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
+                : dateTime.ToUniversalTime();
+
+            return Instant.FromDateTimeUtc(utcDateTime);
+        }
+
+        public Instant Convert(DateTimeOffset source, Instant destination, ResolutionContext context)
+        {
+            return Instant.FromDateTimeOffset(source);
+        }
+
+        public Instant? Convert(DateTimeOffset? source, Instant? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return Instant.FromDateTimeOffset(source.Value);
+        }
+    }
+}

--- a/AutoMapper.NodaTime-Net46/LocalDateConverter.cs
+++ b/AutoMapper.NodaTime-Net46/LocalDateConverter.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using NodaTime;
+
+namespace AutoMapper.NodaTime
+{
+    public class LocalDateConverter :
+        ITypeConverter<LocalDate, DateTime>,
+        ITypeConverter<LocalDate?, DateTime?>,
+        ITypeConverter<DateTime, LocalDate>,
+        ITypeConverter<DateTime?, LocalDate?>
+    {
+        public DateTime Convert(LocalDate source, DateTime destination, ResolutionContext context)
+        {
+            return source.AtMidnight().ToDateTimeUnspecified();
+        }
+
+        public DateTime? Convert(LocalDate? source, DateTime? destination, ResolutionContext context)
+        {
+            if (source == null)
+                return null;
+
+            return source.Value.AtMidnight().ToDateTimeUnspecified();
+        }
+
+        public LocalDate Convert(DateTime source, LocalDate destination, ResolutionContext context)
+        {
+            return LocalDateTime.FromDateTime(source).Date;
+        }
+
+        public LocalDate? Convert(DateTime? source, LocalDate? destination, ResolutionContext context)
+        {
+            if (source == null)
+                return null;
+
+            return LocalDateTime.FromDateTime(source.Value).Date;
+        }
+    }
+}

--- a/AutoMapper.NodaTime-Net46/LocalDateTimeConverter.cs
+++ b/AutoMapper.NodaTime-Net46/LocalDateTimeConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using NodaTime;
+
+namespace AutoMapper.NodaTime
+{
+    public class LocalDateTimeConverter :
+        ITypeConverter<LocalDateTime, DateTime>,
+        ITypeConverter<LocalDateTime?, DateTime?>,
+        ITypeConverter<DateTime, LocalDateTime>,
+        ITypeConverter<DateTime?, LocalDateTime?>
+    {
+        public DateTime Convert(LocalDateTime source, DateTime destination, ResolutionContext context)
+        {
+            return source.ToDateTimeUnspecified();
+        }
+
+        public DateTime? Convert(LocalDateTime? source, DateTime? destination, ResolutionContext context)
+        {
+            return source?.ToDateTimeUnspecified();
+        }
+
+        public LocalDateTime Convert(DateTime source, LocalDateTime destination, ResolutionContext context)
+        {
+            return LocalDateTime.FromDateTime(source);
+        }
+
+        public LocalDateTime? Convert(DateTime? source, LocalDateTime? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return LocalDateTime.FromDateTime(source.Value);
+        }
+    }
+}

--- a/AutoMapper.NodaTime-Net46/LocalTimeConverter.cs
+++ b/AutoMapper.NodaTime-Net46/LocalTimeConverter.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using NodaTime;
+
+namespace AutoMapper.NodaTime
+{
+    public class LocalTimeConverter :
+        ITypeConverter<LocalTime, TimeSpan>,
+        ITypeConverter<LocalTime?, TimeSpan?>,
+        ITypeConverter<TimeSpan, LocalTime>,
+        ITypeConverter<TimeSpan?, LocalTime?>,
+        ITypeConverter<LocalTime, DateTime>,
+        ITypeConverter<LocalTime?, DateTime?>,
+        ITypeConverter<DateTime, LocalTime>,
+        ITypeConverter<DateTime?, LocalTime?>
+    {
+        public TimeSpan Convert(LocalTime source, TimeSpan destination, ResolutionContext context)
+        {
+            return new TimeSpan(source.TickOfDay);
+        }
+
+        public TimeSpan? Convert(LocalTime? source, TimeSpan? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return new TimeSpan(source.Value.TickOfDay);
+        }
+
+        public LocalTime Convert(TimeSpan source, LocalTime destination, ResolutionContext context)
+        {
+            return LocalTime.FromTicksSinceMidnight(source.Ticks);
+        }
+
+        public LocalTime? Convert(TimeSpan? source, LocalTime? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return LocalTime.FromTicksSinceMidnight(source.Value.Ticks);
+        }
+
+        public DateTime Convert(LocalTime source, DateTime destination, ResolutionContext context)
+        {
+            return source.On(new LocalDate(1, 1, 1)).ToDateTimeUnspecified();
+        }
+
+        public DateTime? Convert(LocalTime? source, DateTime? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return source.Value.On(new LocalDate(1, 1, 1)).ToDateTimeUnspecified();
+        }
+
+        public LocalTime Convert(DateTime source, LocalTime destination, ResolutionContext context)
+        {
+            return LocalDateTime.FromDateTime(source).TimeOfDay;
+        }
+
+        public LocalTime? Convert(DateTime? source, LocalTime? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return LocalDateTime.FromDateTime(source.Value).TimeOfDay;
+        }
+    }
+}

--- a/AutoMapper.NodaTime-Net46/NodaTimeProfile.cs
+++ b/AutoMapper.NodaTime-Net46/NodaTimeProfile.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using NodaTime;
+
+namespace AutoMapper.NodaTime
+{
+    public class NodaTimeProfile : Profile
+    {
+        public override string ProfileName => nameof(NodaTimeProfile);
+
+        public NodaTimeProfile()
+        {
+            CreateMappingsForDurationConverter();
+            CreateMappingsForInstantConvertor();
+            CreateMappingsForLocalDateConverter();
+            CreateMappingsForLocalDateTimeConverter();
+            CreateMappingsForLocalTimeConverter();
+            CreateMappingsForOffsetConverter();
+            CreateMappingsForOffsetDateTimeConverter();
+            CreateMappingsForPeriodConverter();
+        }
+
+        private void CreateMappingsForDurationConverter()
+        {
+            CreateMap<Duration, TimeSpan>().ConvertUsing<DurationConverter>();
+            CreateMap<Duration?, TimeSpan?>().ConvertUsing<DurationConverter>();
+            CreateMap<TimeSpan, Duration>().ConvertUsing<DurationConverter>();
+            CreateMap<TimeSpan?, Duration?>().ConvertUsing<DurationConverter>();
+            CreateMap<Duration, long>().ConvertUsing<DurationConverter>();
+            CreateMap<Duration?, long?>().ConvertUsing<DurationConverter>();
+            CreateMap<long, Duration>().ConvertUsing<DurationConverter>();
+            CreateMap<long?, Duration?>().ConvertUsing<DurationConverter>();
+            CreateMap<Duration, int>().ConvertUsing<DurationConverter>();
+            CreateMap<Duration?, int?>().ConvertUsing<DurationConverter>();
+            CreateMap<int, Duration>().ConvertUsing<DurationConverter>();
+            CreateMap<int?, Duration?>().ConvertUsing<DurationConverter>();
+            CreateMap<Duration, double>().ConvertUsing<DurationConverter>();
+            CreateMap<Duration?, double?>().ConvertUsing<DurationConverter>();
+            CreateMap<double, Duration>().ConvertUsing<DurationConverter>();
+            CreateMap<double?, Duration?>().ConvertUsing<DurationConverter>();
+            CreateMap<Duration, decimal>().ConvertUsing<DurationConverter>();
+            CreateMap<Duration?, decimal?>().ConvertUsing<DurationConverter>();
+            CreateMap<decimal, Duration>().ConvertUsing<DurationConverter>();
+            CreateMap<decimal?, Duration?>().ConvertUsing<DurationConverter>();
+        }
+
+        private void CreateMappingsForInstantConvertor()
+        {
+            CreateMap<Instant, DateTime>().ConvertUsing<InstantConverter>();
+            CreateMap<Instant?, DateTime?>().ConvertUsing<InstantConverter>();
+            CreateMap<Instant, DateTimeOffset>().ConvertUsing<InstantConverter>();
+            CreateMap<Instant?, DateTimeOffset?>().ConvertUsing<InstantConverter>();
+            CreateMap<DateTime, Instant>().ConvertUsing<InstantConverter>();
+            CreateMap<DateTime?, Instant?>().ConvertUsing<InstantConverter>();
+            CreateMap<DateTimeOffset, Instant>().ConvertUsing<InstantConverter>();
+            CreateMap<DateTimeOffset?, Instant?>().ConvertUsing<InstantConverter>();
+        }
+
+        private void CreateMappingsForLocalDateConverter()
+        {
+            CreateMap<LocalDate, DateTime>().ConvertUsing<LocalDateConverter>();
+            CreateMap<LocalDate?, DateTime?>().ConvertUsing<LocalDateConverter>();
+            CreateMap<DateTime, LocalDate>().ConvertUsing<LocalDateConverter>();
+            CreateMap<DateTime?, LocalDate?>().ConvertUsing<LocalDateConverter>();
+        }
+
+        private void CreateMappingsForLocalDateTimeConverter()
+        {
+            CreateMap<LocalDateTime, DateTime>().ConvertUsing<LocalDateTimeConverter>();
+            CreateMap<LocalDateTime?, DateTime?>().ConvertUsing<LocalDateTimeConverter>();
+            CreateMap<DateTime, LocalDateTime>().ConvertUsing<LocalDateTimeConverter>();
+            CreateMap<DateTime?, LocalDateTime?>().ConvertUsing<LocalDateTimeConverter>();
+        }
+
+        private void CreateMappingsForLocalTimeConverter()
+        {
+            CreateMap<LocalTime, TimeSpan>().ConvertUsing<LocalTimeConverter>();
+            CreateMap<LocalTime?, TimeSpan?>().ConvertUsing<LocalTimeConverter>();
+            CreateMap<TimeSpan, LocalTime>().ConvertUsing<LocalTimeConverter>();
+            CreateMap<TimeSpan?, LocalTime?>().ConvertUsing<LocalTimeConverter>();
+            CreateMap<LocalTime, DateTime>().ConvertUsing<LocalTimeConverter>();
+            CreateMap<LocalTime?, DateTime?>().ConvertUsing<LocalTimeConverter>();
+            CreateMap<DateTime, LocalTime>().ConvertUsing<LocalTimeConverter>();
+            CreateMap<DateTime?, LocalTime?>().ConvertUsing<LocalTimeConverter>();
+        }
+
+        private void CreateMappingsForOffsetConverter()
+        {
+            CreateMap<Offset, TimeSpan>().ConvertUsing<OffsetConverter>();
+            CreateMap<Offset?, TimeSpan?>().ConvertUsing<OffsetConverter>();
+            CreateMap<TimeSpan, Offset>().ConvertUsing<OffsetConverter>();
+            CreateMap<TimeSpan?, Offset?>().ConvertUsing<OffsetConverter>();
+        }
+
+        private void CreateMappingsForOffsetDateTimeConverter()
+        {
+            CreateMap<OffsetDateTime, DateTimeOffset>().ConvertUsing<OffsetDateTimeConverter>();
+            CreateMap<OffsetDateTime?, DateTimeOffset?>().ConvertUsing<OffsetDateTimeConverter>();
+            CreateMap<DateTimeOffset, OffsetDateTime>().ConvertUsing<OffsetDateTimeConverter>();
+            CreateMap<DateTimeOffset?, OffsetDateTime?>().ConvertUsing<OffsetDateTimeConverter>();
+        }
+
+        private void CreateMappingsForPeriodConverter()
+        {
+            CreateMap<Period, string>().ConvertUsing<PeriodConverter>();
+            CreateMap<string, Period>().ConvertUsing<PeriodConverter>();
+        }
+    }
+}

--- a/AutoMapper.NodaTime-Net46/OffsetConverter.cs
+++ b/AutoMapper.NodaTime-Net46/OffsetConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using NodaTime;
+
+namespace AutoMapper.NodaTime
+{
+    public class OffsetConverter :
+        ITypeConverter<Offset, TimeSpan>,
+        ITypeConverter<Offset?, TimeSpan?>,
+        ITypeConverter<TimeSpan, Offset>,
+        ITypeConverter<TimeSpan?, Offset?>
+    {
+        public TimeSpan Convert(Offset source, TimeSpan destination, ResolutionContext context)
+        {
+            return source.ToTimeSpan();
+        }
+
+        public TimeSpan? Convert(Offset? source, TimeSpan? destination, ResolutionContext context)
+        {
+            return source?.ToTimeSpan();
+        }
+
+        public Offset Convert(TimeSpan source, Offset destination, ResolutionContext context)
+        {
+            return Offset.FromTicks(source.Ticks);
+        }
+
+        public Offset? Convert(TimeSpan? source, Offset? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return Offset.FromTicks(source.Value.Ticks);
+        }
+    }
+}

--- a/AutoMapper.NodaTime-Net46/OffsetDateTimeConverter.cs
+++ b/AutoMapper.NodaTime-Net46/OffsetDateTimeConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using NodaTime;
+
+namespace AutoMapper.NodaTime
+{
+    public class OffsetDateTimeConverter :
+        ITypeConverter<OffsetDateTime, DateTimeOffset>,
+        ITypeConverter<OffsetDateTime?, DateTimeOffset?>,
+        ITypeConverter<DateTimeOffset, OffsetDateTime>,
+        ITypeConverter<DateTimeOffset?, OffsetDateTime?>
+    {
+        public DateTimeOffset Convert(OffsetDateTime source, DateTimeOffset destination, ResolutionContext context)
+        {
+            return source.ToDateTimeOffset();
+        }
+
+        public DateTimeOffset? Convert(OffsetDateTime? source, DateTimeOffset? destination, ResolutionContext context)
+        {
+            return source?.ToDateTimeOffset();
+        }
+
+        public OffsetDateTime Convert(DateTimeOffset source, OffsetDateTime destination, ResolutionContext context)
+        {
+            return OffsetDateTime.FromDateTimeOffset(source);
+        }
+
+        public OffsetDateTime? Convert(DateTimeOffset? source, OffsetDateTime? destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return OffsetDateTime.FromDateTimeOffset(source.Value);
+        }
+    }
+}

--- a/AutoMapper.NodaTime-Net46/PeriodConverter.cs
+++ b/AutoMapper.NodaTime-Net46/PeriodConverter.cs
@@ -1,0 +1,25 @@
+﻿using NodaTime;
+using NodaTime.Text;
+
+namespace AutoMapper.NodaTime
+{
+    public class PeriodConverter :
+        ITypeConverter<Period, string>,
+        ITypeConverter<string, Period>
+    {
+        public string Convert(Period source, string destination, ResolutionContext context)
+        {
+            return source?.ToString();
+        }
+
+        public Period Convert(string source, Period destination, ResolutionContext context)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            return PeriodPattern.RoundtripPattern.Parse(source).Value;
+        }
+    }
+}

--- a/AutoMapper.NodaTime-Net46/Properties/AssemblyInfo.cs
+++ b/AutoMapper.NodaTime-Net46/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AutoMapper.NodaTime-Net46")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AutoMapper.NodaTime-Net46")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fb772c38-2e94-4633-acc7-6a1b34fe39de")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/AutoMapper.NodaTime-Net46/packages.config
+++ b/AutoMapper.NodaTime-Net46/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AutoMapper" version="6.0.2" targetFramework="net461" />
+  <package id="NodaTime" version="1.3.4" targetFramework="net461" />
+</packages>

--- a/AutoMapper.NodaTime.UnitTests/OffsetDateTimeTests.cs
+++ b/AutoMapper.NodaTime.UnitTests/OffsetDateTimeTests.cs
@@ -16,8 +16,8 @@ namespace AutoMapper.NodaTime.UnitTests
 
                 x.CreateMap<Foo1, Foo3>().ReverseMap();
                 x.CreateMap<Foo2, Foo4>().ReverseMap();
-                x.CreateMap<Foo1, Foo5>().ReverseMap();
-                x.CreateMap<Foo2, Foo6>().ReverseMap();
+                x.CreateMap<Foo3, Foo1>().ReverseMap();
+                x.CreateMap<Foo4, Foo2>().ReverseMap();
             });
 
             Mapper.AssertConfigurationIsValid();
@@ -25,30 +25,20 @@ namespace AutoMapper.NodaTime.UnitTests
 
         public class Foo1
         {
-            public Instant Bar { get; set; }
+            public OffsetDateTime Bar { get; set; }
         }
 
         public class Foo2
         {
-            public Instant? Bar { get; set; }
+            public OffsetDateTime? Bar { get; set; }
         }
 
         public class Foo3
         {
-            public DateTime Bar { get; set; }
-        }
-
-        public class Foo4
-        {
-            public DateTime? Bar { get; set; }
-        }
-
-        public class Foo5
-        {
             public DateTimeOffset Bar { get; set; }
         }
 
-        public class Foo6
+        public class Foo4
         {
             public DateTimeOffset? Bar { get; set; }
         }

--- a/AutoMapper.NodaTime.sln
+++ b/AutoMapper.NodaTime.sln
@@ -1,13 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.10
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoMapper.NodaTime", "AutoMapper.NodaTime\AutoMapper.NodaTime.csproj", "{49C9C765-57C6-4E34-83A7-14928A5BC964}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoMapper.NodaTime (Net40)", "AutoMapper.NodaTime-Net40\AutoMapper.NodaTime (Net40).csproj", "{20EEA7A4-D947-4367-9873-A2CBE474E776}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoMapper.NodaTime.UnitTests", "AutoMapper.NodaTime.UnitTests\AutoMapper.NodaTime.UnitTests.csproj", "{1AA7C64D-C602-49B3-8359-9DF251A8DBBA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoMapper.NodaTime (Net46)", "AutoMapper.NodaTime-Net46\AutoMapper.NodaTime (Net46).csproj", "{FB772C38-2E94-4633-ACC7-6A1B34FE39DE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoMapper.NodaTime-NET46.UnitTests", "AutoMapper.NodaTime-NET46.UnitTests\AutoMapper.NodaTime-NET46.UnitTests.csproj", "{C55CADC8-7CA4-4CB6-AAA8-56DE7A4EF37B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +31,14 @@ Global
 		{1AA7C64D-C602-49B3-8359-9DF251A8DBBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1AA7C64D-C602-49B3-8359-9DF251A8DBBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1AA7C64D-C602-49B3-8359-9DF251A8DBBA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB772C38-2E94-4633-ACC7-6A1B34FE39DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB772C38-2E94-4633-ACC7-6A1B34FE39DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB772C38-2E94-4633-ACC7-6A1B34FE39DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB772C38-2E94-4633-ACC7-6A1B34FE39DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C55CADC8-7CA4-4CB6-AAA8-56DE7A4EF37B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C55CADC8-7CA4-4CB6-AAA8-56DE7A4EF37B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C55CADC8-7CA4-4CB6-AAA8-56DE7A4EF37B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C55CADC8-7CA4-4CB6-AAA8-56DE7A4EF37B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- added version of library with support of .NET 4.6.1
- updated components to latest AutoMapper and NodaTime
- removed unsupported functionality (DurationAttribute) - it's not possible to easy use this attribute due to changes API interfaces and some restrictions related to current implementation of AutoMapper
- fixed unit test

Can be edited with VS2015-2017
